### PR TITLE
Add tests for plot_pesos

### DIFF
--- a/metrics/plot_pesos.py
+++ b/metrics/plot_pesos.py
@@ -9,6 +9,7 @@ import matplotlib.pyplot as plt
 def plotar(
     pesos_path: str = "pesos.json",
     img_path: str = "grafico_pesos.png",
+    mostrar: bool = False,
 ) -> None:
     """Lê o ficheiro de pesos e salva um gráfico.
 
@@ -18,12 +19,16 @@ def plotar(
         Caminho para o JSON com os pesos.
     img_path : str
         Ficheiro onde o gráfico será guardado.
+    mostrar : bool, optional
+        Se ``True`` exibe o gráfico na tela. O padrão é ``False``.
     """
     caminho = Path(pesos_path)
     if not caminho.exists():
         raise FileNotFoundError(pesos_path)
     with caminho.open("r", encoding="utf-8") as f:
         pesos = json.load(f)
+    if not isinstance(pesos, dict):
+        raise ValueError("JSON de pesos inválido: esperado objeto com pares chave/valor")
 
     plt.figure()
     plt.bar(pesos.keys(), pesos.values())
@@ -31,6 +36,8 @@ def plotar(
     plt.xlabel("Contexto")
     plt.title("Evolução dos Pesos")
     plt.savefig(img_path)
+    if mostrar:
+        plt.show()
     plt.close()
 
 

--- a/tests/test_plot_pesos.py
+++ b/tests/test_plot_pesos.py
@@ -1,0 +1,40 @@
+"""Testes para plot_pesos."""
+
+import json
+
+import pytest
+import matplotlib
+
+matplotlib.use("Agg")
+
+from metrics import plot_pesos
+
+
+def test_plotar_cria_grafico(tmp_path):
+    """Verifica se a imagem é criada corretamente."""
+    pesos = {"rsi": 1.5, "macd": 2.0}
+    pesos_path = tmp_path / "pesos.json"
+    pesos_path.write_text(json.dumps(pesos), encoding="utf-8")
+
+    img_path = tmp_path / "grafico_pesos.png"
+
+    plot_pesos.plotar(pesos_path=str(pesos_path), img_path=str(img_path), mostrar=False)
+
+    assert img_path.exists()
+
+
+def test_plotar_erro_ao_nao_existir_pesos(tmp_path):
+    """Gera FileNotFoundError quando o JSON não existe."""
+    caminho_inexistente = tmp_path / "nao_existe.json"
+    img_path = tmp_path / "graf.png"
+    with pytest.raises(FileNotFoundError):
+        plot_pesos.plotar(pesos_path=str(caminho_inexistente), img_path=str(img_path), mostrar=False)
+
+
+def test_plotar_erro_json_invalido(tmp_path):
+    """Dispara ValueError quando o JSON não contém um objeto."""
+    pesos_path = tmp_path / "pesos.json"
+    pesos_path.write_text("[1, 2, 3]", encoding="utf-8")
+    img_path = tmp_path / "graf.png"
+    with pytest.raises(ValueError):
+        plot_pesos.plotar(pesos_path=str(pesos_path), img_path=str(img_path), mostrar=False)


### PR DESCRIPTION
## Summary
- validate JSON contents in `metrics.plot_pesos.plotar`
- add optional `mostrar` parameter
- add unit tests for the plotting helper

## Testing
- `pytest tests/test_plot_pesos.py -q`
- `pytest tests/test_metrics.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685b1a20cc90833288c1f734db70261a