### PR TITLE
Add new tests covering engine decision and strategies

### DIFF
--- a/core/engine.py
+++ b/core/engine.py
@@ -50,3 +50,15 @@ class Engine:
         except Exception as exc:  # noqa: BLE001
             self.logger_erros.error("Erro na simulação: %s", exc)
             raise
+
+    def executar_decisao(
+        self, estrategias: dict[str, callable], pesos: dict[str, float]
+    ) -> str:
+        """Seleciona e executa a estratégia com maior peso."""
+        if not estrategias:
+            raise ValueError("Nenhuma estratégia fornecida")
+        nome_melhor = max(pesos, key=pesos.get)
+        estrategia = estrategias.get(nome_melhor)
+        if estrategia is None:
+            raise KeyError(nome_melhor)
+        return estrategia()

--- a/simulator/generate_data.py
+++ b/simulator/generate_data.py
@@ -1,0 +1,18 @@
+"""Gerador simplificado de dados de mercado."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+import numpy as np
+
+
+def gerar_dados(n: int) -> Dict[str, List[float]]:
+    """Gera n pontos de dados fictícios para indicadores."""
+    if n <= 0:
+        raise ValueError("n deve ser positivo")
+    rsi = np.random.uniform(0, 100, n).tolist()
+    macd = np.random.uniform(-5, 5, n).tolist()
+    signal = np.random.uniform(-5, 5, n).tolist()
+    preco = np.random.uniform(50, 150, n).tolist()
+    return {"rsi": rsi, "macd": macd, "signal": signal, "preco": preco}

--- a/strategies/basic.py
+++ b/strategies/basic.py
@@ -1,0 +1,11 @@
+"""Estratégias de exemplo."""
+
+
+def rsi_buy_strategy(rsi: float) -> str:
+    """Retorna 'comprar' se RSI < 30, caso contrário 'nada'."""
+    return "comprar" if rsi < 30 else "nada"
+
+
+def macd_cross_strategy(macd: float, signal: float) -> str:
+    """Retorna 'comprar' se MACD > signal, senão 'vender'."""
+    return "comprar" if macd > signal else "vender"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -13,3 +13,20 @@ def test_run_simulation_chama_run(monkeypatch):
     engine = Engine()
     engine.run_simulation()
     assert chamado["ok"]
+
+
+def test_executar_decisao_maior_peso() -> None:
+    """Escolhe a estratégia com o peso mais alto."""
+    engine = Engine()
+
+    def estrategia_1() -> str:
+        return "comprar"
+
+    def estrategia_2() -> str:
+        return "vender"
+
+    estrategias = {"estrategia_1": estrategia_1, "estrategia_2": estrategia_2}
+    pesos = {"estrategia_1": 1.0, "estrategia_2": 2.0}
+    resultado = engine.executar_decisao(estrategias, pesos)
+    assert isinstance(resultado, str)
+    assert resultado == "vender"

--- a/tests/test_generate_data.py
+++ b/tests/test_generate_data.py
@@ -3,15 +3,32 @@
 import pandas as pd
 import pytest
 
-from simulator.data_generator import gerar_dados
+from simulator.data_generator import gerar_dados as gerar_df
+from simulator.generate_data import gerar_dados
 
 
-def test_gerar_dados_tamanho():
-    df = gerar_dados(5)
+def test_gerar_dados_dataframe():
+    """Gera DataFrame com tamanho correto."""
+    df = gerar_df(5)
     assert isinstance(df, pd.DataFrame)
     assert len(df) == 5
 
 
 def test_gerar_dados_invalido():
+    """Falha quando ``num_pontos`` é inválido."""
     with pytest.raises(ValueError):
-        gerar_dados(0)
+        gerar_df(0)
+
+
+def test_generate_data_formato_e_intervalos():
+    """Listas devem ter o mesmo tamanho e valores esperados."""
+    n = 10
+    dados = gerar_dados(n)
+    assert set(dados.keys()) == {"rsi", "macd", "signal", "preco"}
+    for valores in dados.values():
+        assert isinstance(valores, list)
+        assert len(valores) == n
+    assert all(0 <= v <= 100 for v in dados["rsi"])
+    assert all(-5 <= v <= 5 for v in dados["macd"])
+    assert all(-5 <= v <= 5 for v in dados["signal"])
+    assert all(v > 0 for v in dados["preco"])

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -4,6 +4,7 @@ from strategies.rsi import signal as rsi
 from strategies.macd import signal as macd
 from strategies.ema import signal as ema
 from strategies.bollinger import signal as bollinger
+from strategies.basic import macd_cross_strategy, rsi_buy_strategy
 
 
 def test_rsi() -> None:
@@ -24,3 +25,15 @@ def test_ema() -> None:
 def test_bollinger() -> None:
     assert bollinger(3) == "VENDA"
     assert bollinger(-3) == "COMPRA"
+
+
+def test_rsi_buy_strategy() -> None:
+    """Compras abaixo de 30."""
+    assert rsi_buy_strategy(20) == "comprar"
+    assert rsi_buy_strategy(40) == "nada"
+
+
+def test_macd_cross_strategy() -> None:
+    """Compra quando MACD cruza acima do sinal."""
+    assert macd_cross_strategy(1, 0) == "comprar"
+    assert macd_cross_strategy(-1, 0) == "vender"


### PR DESCRIPTION
## Summary
- extend `Engine` with `executar_decisao` to pick the strategy with highest weight
- add simplified data generator returning indicator lists
- include example strategies `rsi_buy_strategy` and `macd_cross_strategy`
- create tests for decision logic, new data generator and new strategies

## Testing
- `pre-commit run --files core/engine.py simulator/generate_data.py strategies/basic.py tests/test_engine.py tests/test_generate_data.py tests/test_strategies.py`
- `pytest -q` *(fails: ModuleNotFoundError for pandas/numpy/matplotlib)*

------
https://chatgpt.com/codex/tasks/task_e_685b215459248332ad89a37ed1e0147e