### PR TITLE
Add new stub API clients

### DIFF
--- a/ai/openai/README.md
+++ b/ai/openai/README.md
@@ -1,0 +1,13 @@
+# Módulo `ai.openai`
+
+Este diretório contém clientes prontos para futuras integrações com APIs
+externas. No momento, as chamadas são simuladas para facilitar o
+ desenvolvimento e testes.
+
+## Classes Disponíveis
+
+- `OpenAIClient` – interface simples para enviar prompts à OpenAI.
+- `XTBClient` – exemplo de cliente para interação com brokers como a XTB.
+
+**Aviso:** a integração real ainda não está ativa; as respostas são
+mockadas.

--- a/ai/openai/__init__.py
+++ b/ai/openai/__init__.py
@@ -1,1 +1,6 @@
-"""Integração futura com APIs da OpenAI."""
+"""Integração simulada com APIs externas."""
+
+from .openai_client import OpenAIClient
+from .xtb_client import XTBClient
+
+__all__ = ["OpenAIClient", "XTBClient"]

--- a/ai/openai/openai_client.py
+++ b/ai/openai/openai_client.py
@@ -1,0 +1,37 @@
+"""Cliente para interação com a API da OpenAI (stub).
+
+Exemplo de uso:
+    >>> client = OpenAIClient("SUA-API-KEY")
+    >>> resposta = client.consultar_modelo("Olá")
+"""
+
+from __future__ import annotations
+
+import requests
+
+
+class OpenAIClient:
+    """Wrapper simplificado para chamadas à API da OpenAI."""
+
+    def __init__(self, api_key: str) -> None:
+        """Guarda a API key e prepara os cabeçalhos de autenticação."""
+        self.api_key = api_key
+        self.headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def consultar_modelo(self, prompt: str, modelo: str = "gpt-3.5-turbo") -> str:
+        """Envia um prompt ao modelo indicado e devolve a resposta textual."""
+        # payload = {
+        #     "model": modelo,
+        #     "messages": [{"role": "user", "content": prompt}],
+        # }
+        # response = requests.post(
+        #     "https://api.openai.com/v1/chat/completions",
+        #     headers=self.headers,
+        #     json=payload,
+        #     timeout=10,
+        # )
+        # return response.json()["choices"][0]["message"]["content"]
+        return f"Resposta simulada do modelo: {prompt}"

--- a/ai/openai/xtb_client.py
+++ b/ai/openai/xtb_client.py
@@ -1,0 +1,16 @@
+"""Cliente de integração futura com a API da XTB (stub)."""
+
+
+class XTBClient:
+    """Facilita a comunicação com a XTB de forma simplificada."""
+
+    def login(self, user: str, password: str):
+        """Realiza login simulando sucesso."""
+        # Aqui ocorreria a chamada real de autenticação
+        self.user = user
+        return {"status": "login simulado"}
+
+    def executar_ordem(self, tipo: str, ativo: str, volume: float):
+        """Envia uma ordem de compra ou venda (simulada)."""
+        # Implementação real de ordem via API ficaria aqui
+        return {"status": "simulado", "tipo": tipo, "ativo": ativo, "volume": volume}


### PR DESCRIPTION
## Summary
- add skeleton OpenAI and XTB client modules
- expose new clients from `ai.openai`
- document the new module

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for requests, pandas, matplotlib, numpy)*

------
https://chatgpt.com/codex/tasks/task_e_685b2632c3148332a7b2ad904e092a07